### PR TITLE
add custom component "hbox"

### DIFF
--- a/quartz/components/HBox.tsx
+++ b/quartz/components/HBox.tsx
@@ -1,0 +1,31 @@
+// @ts-ignore: this is safe, we don't want to actually make darkmode.inline.ts a module as
+// modules are automatically deferred and we don't want that to happen for critical beforeDOMLoads
+// see: https://v8.dev/features/modules#defer
+import darkmodeScript from "./scripts/darkmode.inline"
+import styles from "./styles/hbox.scss"
+import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types";
+
+export default ((components?: QuartzComponent[]) => {
+	if (components && components.length > 0) {
+		function HBox(props: QuartzComponentProps) {
+			// otherwise it complains that components
+			// could be undefined even though we already checked
+			if (!components) return null
+			return (
+				<div class="hbox" {...props} >
+					{components.map((Component) => (
+						<Component {...props} />
+					))}
+				</div>
+			)
+		}
+
+    // hacky - for some reason it doesn't get loaded otherwise
+    HBox.beforeDOMLoaded = darkmodeScript;
+		HBox.css = styles;
+		return HBox
+	} else {
+		return () => <></>
+	}
+
+}) satisfies QuartzComponentConstructor

--- a/quartz/components/styles/hbox.scss
+++ b/quartz/components/styles/hbox.scss
@@ -1,0 +1,22 @@
+@import 'darkmode';
+
+.hbox {
+	flex: 1;
+	display: flex;
+	flex-direction: row;
+	// gap: 2rem;
+	box-sizing: border-box;
+	// padding: 0;
+	align-items: center;
+	// min-width: max-content;
+	
+	& > * {
+		flex: 1;
+		flex-basis: 100%;
+
+	}
+	& > .darkmode {
+		// flex-basis: 0;
+		flex: 0;
+	}
+}


### PR DESCRIPTION
basically just a row-only flexbox for use in the quartz layout configs, sort of hacky. i had a hell of a time getting the darkmode toggle to be styled & function properly (which is the main element i wanted the hbox for), but eventually i got it.